### PR TITLE
Handle notes in status (S) marks

### DIFF
--- a/split-on-maintainer
+++ b/split-on-maintainer
@@ -172,6 +172,9 @@ for line in open('MAINTAINERS'):
 	elif mark in ['K']:
 		patterns[area]['content'].append(rest)
 	elif mark in ['S']:
+		if '(' in rest:
+			rest, note = rest.split('(', 1)
+			rest = rest.strip()
 		if rest in ['Supported', 'Maintained', 'Odd Fixes', 'Odd fixes', 'Buried alive in reporters']:
 			continue
 		elif rest in ['Orphan', 'Obsolete', 'Orphan / Obsolete']:


### PR DESCRIPTION
A recent commit[1] broke the split-on-maintainer tool, this fixes it.

[1] https://kernel.googlesource.com/pub/scm/linux/kernel/git/next/linux-next/+/7cc99ed87e4aeb3738e6ea7dc4d3ae28ad943601%5E%21/