### PR TITLE
Add colors to pass/fail messages

### DIFF
--- a/fortify/harness.h
+++ b/fortify/harness.h
@@ -988,6 +988,16 @@ void __run_test(struct __fixture_metadata *f,
 		struct __fixture_variant_metadata *variant,
 		struct __test_metadata *t)
 {
+	const char *color_red = "\033[0;31m";
+	const char *color_green = "\033[0;32m";
+	const char *color_default = "\033[0m";
+
+	if (!isatty(STDOUT_FILENO)) {
+	    color_red = "";
+	    color_green = "";
+	    color_default = "";
+	}
+
 	/* reset test struct */
 	t->passed = 1;
 	t->skip = 0;
@@ -1020,8 +1030,10 @@ void __run_test(struct __fixture_metadata *f,
 	} else {
 		__wait_for_test(t);
 	}
-	ksft_print_msg("         %4s  %s%s%s.%s\n", t->passed ? "OK" : "FAIL",
-	       f->name, variant->name[0] ? "." : "", variant->name, t->name);
+	ksft_print_msg("         %s%4s%s  %s%s%s.%s\n",
+		       t->passed ? color_green : color_red,
+		       t->passed ? "OK" : "FAIL", color_default,
+		       f->name, variant->name[0] ? "." : "", variant->name, t->name);
 
 	if (t->skip)
 		ksft_test_result_skip("%s\n", t->results->reason[0] ?

--- a/fortify/kselftest.h
+++ b/fortify/kselftest.h
@@ -152,7 +152,7 @@ static inline void ksft_test_result_pass(const char *msg, ...)
 	ksft_cnt.ksft_pass++;
 
 	va_start(args, msg);
-	printf("ok %d ", ksft_test_num());
+	printf("\033[0;32mPASSED\033[0m %d ", ksft_test_num());
 	errno = saved_errno;
 	vprintf(msg, args);
 	va_end(args);
@@ -166,7 +166,7 @@ static inline void ksft_test_result_fail(const char *msg, ...)
 	ksft_cnt.ksft_fail++;
 
 	va_start(args, msg);
-	printf("not ok %d ", ksft_test_num());
+	printf("\033[0;31mFAILED\033[0m %d ", ksft_test_num());
 	errno = saved_errno;
 	vprintf(msg, args);
 	va_end(args);

--- a/fortify/kselftest.h
+++ b/fortify/kselftest.h
@@ -152,7 +152,7 @@ static inline void ksft_test_result_pass(const char *msg, ...)
 	ksft_cnt.ksft_pass++;
 
 	va_start(args, msg);
-	printf("\033[0;32mPASSED\033[0m %d ", ksft_test_num());
+	printf("ok %d ", ksft_test_num());
 	errno = saved_errno;
 	vprintf(msg, args);
 	va_end(args);
@@ -166,7 +166,7 @@ static inline void ksft_test_result_fail(const char *msg, ...)
 	ksft_cnt.ksft_fail++;
 
 	va_start(args, msg);
-	printf("\033[0;31mFAILED\033[0m %d ", ksft_test_num());
+	printf("not ok %d ", ksft_test_num());
 	errno = saved_errno;
 	vprintf(msg, args);
 	va_end(args);


### PR DESCRIPTION
Seeing a green PASS and red FAIL is easier for me to identify what's broken.