### PR TITLE
identity-canonicalizer: final refresh for 2025 TAB Elections

### DIFF
--- a/identity-canonicalizer
+++ b/identity-canonicalizer
@@ -66,6 +66,7 @@ email_ignore_list = [
 	r'from Christian would be very welcome\.',
 	r'for them\?',
 	r'.* \(@[^@]*\)',
+	r'BPF Runtime Fuzzer \(BRF\)',
 ]
 email_ignore_joined = "|".join(email_ignore_list)
 email_ignore = re.compile(f'^({email_ignore_joined})$')


### PR DESCRIPTION
At the moment of running the 2025 TAB Elections, there were two remaining warnings:

    f6fddc6df3fc0cffce329b87927db4eb5989728d: ignoring email without @: BPF Runtime Fuzzer (BRF)
    7f9ee5fc97e14682e36fe22ae2654c07e4998b82: ignoring email without @: BPF Runtime Fuzzer (BRF)

These are commits:

    f6fddc6df3fc ("bpf: Fix memory leak in __lookup_instance error path")
    7f9ee5fc97e1 ("bpf: test_run: Fix ctx leak in bpf_prog_test_run_xdp error path")

Due to the following line:

    Reported-by: BPF Runtime Fuzzer (BRF)

Thus add it to the `email_ignore_list` regex list.